### PR TITLE
Add marker 'pylint' to run pylint checks only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,13 @@ would be the most simple usage and would run pylint for all error messages.
 This would use the pylintrc file at /my/pyrc and only error on pylint
 Errors and Failures.
 
+You can restrict your test run to only perform pylint checks and not any other
+tests by typing:
+
+.. code-block:: shell
+
+    py.test --pylint -m pylint
+
 Acknowledgements
 ================
 

--- a/pytest_pylint.py
+++ b/pytest_pylint.py
@@ -111,6 +111,11 @@ class PyLintItem(pytest.Item, pytest.File):
     def __init__(self, fspath, parent, msg_format=None, pylintrc_file=None):
         super(PyLintItem, self).__init__(fspath, parent)
 
+        if hasattr(self, 'add_marker'):
+            self.add_marker("pylint")
+        else:
+            self.keywords["pylint"] = True
+
         if msg_format is None:
             self._msg_format = '{C}:{line:3d},{column:2d}: {msg} ({symbol})'
         else:

--- a/pytest_pylint.py
+++ b/pytest_pylint.py
@@ -111,10 +111,7 @@ class PyLintItem(pytest.Item, pytest.File):
     def __init__(self, fspath, parent, msg_format=None, pylintrc_file=None):
         super(PyLintItem, self).__init__(fspath, parent)
 
-        if hasattr(self, 'add_marker'):
-            self.add_marker("pylint")
-        else:
-            self.keywords["pylint"] = True
+        self.add_marker("pylint")
 
         if msg_format is None:
             self._msg_format = '{C}:{line:3d},{column:2d}: {msg} ({symbol})'


### PR DESCRIPTION
You can run `py.test --pylint -m pylint` to just run the linter and no
other tests.

This functionality is directly adopted from https://github.com/fschulze/pytest-flakes .