### PR TITLE
Prerun linter

### DIFF
--- a/pytest_pylint.py
+++ b/pytest_pylint.py
@@ -116,9 +116,9 @@ def pytest_collect_file(path, parent):
 
 
 def pytest_collection_finish(session):
-    """Lint collected files and store messages on session"""
-    print('-' * 65)
-    print('Linting files')
+    """Lint collected files and store messages on session."""
+    if not session.pylint_files:
+        return
     reporter = ProgrammaticReporter()
     # Build argument list for pylint
     args_list = list(session.pylint_files)
@@ -126,6 +126,8 @@ def pytest_collection_finish(session):
         args_list.append('--rcfile={0}'.format(
             session.pylintrc_file
         ))
+    print('-' * 65)
+    print('Linting files')
     # Run pylint over the collected files.
     result = lint.Run(args_list, reporter=reporter, exit=False)
     messages = result.linter.reporter.data


### PR DESCRIPTION
This change moves the run of the linter to occur after the collection but before the rest of the tests.  This offers two advantages:

1. By running the linter over all files concurrently, messages such as duplicate-code can be picked up which was not possible previously.
2. pytest-pylint currently clashes with pytest-cov in that when both are activate linting takes 10x longer than normal.  On my project of 83 files linting takes ~690 seconds.  This seems to be due to the traceback behaviour of coverage clashing with how astroid assesses syntax.  As long as the linter is run within the Items this will always be a problem.  By moving the linter ahead of the test run, and altering pytest-cov to start the coverage run later, the clash should be avoidable.