### PR TITLE
Show full relative path to file under test

### DIFF
--- a/pytest_pylint.py
+++ b/pytest_pylint.py
@@ -233,4 +233,4 @@ class PyLintItem(pytest.Item, pytest.File):
 
     def reportinfo(self):
         """Generate our test report"""
-        return self.fspath, None, "[pylint] {0}".format(self.name)
+        return self.fspath, None, "[pylint] {0}".format(self.rel_path)

--- a/test_pytest_pylint.py
+++ b/test_pytest_pylint.py
@@ -19,6 +19,20 @@ def test_basic(testdir):
     assert 'Linting files' in result.stdout.str()
 
 
+def test_subdirectories(testdir):
+    """Verify pylint checks files in subdirectories"""
+    subdir = testdir.mkpydir('mymodule')
+    testfile = subdir.join("test_file.py")
+    testfile.write("""import sys""")
+    result = testdir.runpytest('--pylint')
+    assert '[pylint] mymodule/test_file.py' in result.stdout.str()
+    assert 'Missing module docstring' in result.stdout.str()
+    assert 'Unused import sys' in result.stdout.str()
+    assert 'Final newline missing' in result.stdout.str()
+    assert '1 failed' in result.stdout.str()
+    assert 'Linting files' in result.stdout.str()
+
+
 def test_disable(testdir):
     """Verify basic pylint checks"""
     testdir.makepyfile("""import sys""")


### PR DESCRIPTION
Addresses a minor lingering issue to #62 (thanks for the fix, btw, confirmed that it works for our internal project).

I've pushed another repro commit to https://github.com/jamur2/pytest-repro demonstrating that the test output only shows the test name but not the full relative path to some failing files.

Prior to this PR:

```
± pipenv run pytest
============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.7.0, pytest-3.7.4, py-1.6.0, pluggy-0.7.1
rootdir: /Users/jackie.murphy/rally/pylint-repro, inifile: pytest.ini
plugins: pylint-0.12.2
collected 3 items
-----------------------------------------------------------------
Linting files
...
-----------------------------------------------------------------

myrepo/__init__.py F                                                                                                                                                       [ 33%]
myrepo/mymodule/__init__.py F                                                                                                                                              [ 66%]
myrepo/mymodule/foo.py F                                                                                                                                                   [100%]

==================================================================================== FAILURES ====================================================================================
__________________________________________________________________________ [pylint] myrepo/__init__.py ___________________________________________________________________________
C:  1,30: Trailing whitespace (trailing-whitespace)
______________________________________________________________________________ [pylint] __init__.py ______________________________________________________________________________
C:  1,30: Trailing whitespace (trailing-whitespace)
________________________________________________________________________________ [pylint] foo.py _________________________________________________________________________________
C:  1,21: Trailing whitespace (trailing-whitespace)
C:  1, 0: Black listed name "foo" (blacklisted-name)
============================================================================ 3 failed in 0.13 seconds ============================================================================
```

With this PR:

```
± pipenv run pytest
============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.7.0, pytest-3.7.4, py-1.6.0, pluggy-0.7.1
rootdir: /Users/jackie.murphy/rally/pylint-repro, inifile: pytest.ini
plugins: pylint-0.12.2
collected 3 items
-----------------------------------------------------------------
Linting files
...
-----------------------------------------------------------------

myrepo/__init__.py F                                                                                                                                                       [ 33%]
myrepo/mymodule/__init__.py F                                                                                                                                              [ 66%]
myrepo/mymodule/foo.py F                                                                                                                                                   [100%]

==================================================================================== FAILURES ====================================================================================
__________________________________________________________________________ [pylint] myrepo/__init__.py ___________________________________________________________________________
C:  1,30: Trailing whitespace (trailing-whitespace)
______________________________________________________________________ [pylint] myrepo/mymodule/__init__.py ______________________________________________________________________
C:  1,30: Trailing whitespace (trailing-whitespace)
________________________________________________________________________ [pylint] myrepo/mymodule/foo.py _________________________________________________________________________
C:  1,21: Trailing whitespace (trailing-whitespace)
C:  1, 0: Black listed name "foo" (blacklisted-name)
============================================================================ 3 failed in 0.14 seconds ============================================================================
```

Warning that I've never poked at pytest plugins before, so this is a result of poking at pytest_pylint.py, but with no domain knowledge whatsoever.  This "works" for the repro repo and our internal project, but dunno if there are any unintended consequences elsewhere.