### PR TITLE
Fix issue #71

### DIFF
--- a/pytest_pylint.py
+++ b/pytest_pylint.py
@@ -135,6 +135,11 @@ def pytest_sessionstart(session):
             pass
 
 
+def include_file(path, ignore_list):
+    """Checks if a file should be included in the collection."""
+    return not any(basename in path for basename in ignore_list)
+
+
 def pytest_collect_file(path, parent):
     """Collect files on which pylint should run"""
     config = parent.session.config
@@ -149,7 +154,7 @@ def pytest_collect_file(path, parent):
         # No pylintrc, therefore no ignores, so return the item.
         return PyLintItem(path, parent)
 
-    if not any(basename in rel_path for basename in session.pylint_ignore):
+    if include_file(rel_path, session.pylint_ignore):
         session.pylint_files.add(rel_path)
         return PyLintItem(
             path, parent, session.pylint_msg_template, session.pylintrc_file

--- a/pytest_pylint.py
+++ b/pytest_pylint.py
@@ -137,7 +137,8 @@ def pytest_sessionstart(session):
 
 def include_file(path, ignore_list):
     """Checks if a file should be included in the collection."""
-    return not any(basename in path for basename in ignore_list)
+    parts = path.split(sep)
+    return not set(parts) & set(ignore_list)
 
 
 def pytest_collect_file(path, parent):

--- a/test_pytest_pylint.py
+++ b/test_pytest_pylint.py
@@ -160,3 +160,29 @@ def test_no_multiple_jobs(testdir):
         testdir.runpytest('--pylint')
     assert run_mock.call_count == 1
     assert '-j' not in run_mock.call_args[0][0]
+
+
+def test_include_path():
+    """
+    Files should only be included in the list if none of the directories on
+    it's path, of the filename, match an entry in the ignore list.
+    """
+    from pytest_pylint import include_file
+    ignore_list = [
+        "first", "second", "third", "part", "base.py"
+    ]
+    # Default includes.
+    assert include_file("random", ignore_list) is True
+    assert include_file("random/filename", ignore_list) is True
+    assert include_file("random/other/filename", ignore_list) is True
+    # Basic ignore matches.
+    assert include_file("first/filename", ignore_list) is False
+    assert include_file("random/base.py", ignore_list) is False
+    # Part on paths.
+    assert include_file("part/second/filename.py", ignore_list) is False
+    assert include_file("random/part/filename.py", ignore_list) is False
+    assert include_file("random/second/part.py", ignore_list) is False
+    # Part as substring on paths.
+    assert include_file("part_it/other/filename.py", ignore_list) is True
+    assert include_file("random/part_it/filename.py", ignore_list) is True
+    assert include_file("random/other/part_it.py", ignore_list) is True


### PR DESCRIPTION
As mentioned, here's my suggested fix for issue #71.  I've added a unit test to check include_path for a number of potential paths.  I've assumed Linux paths as that seems to follow the test for get_rel_path.

When I ran my tests through Travis it appears that test_basic is failing on Python 2.7.  As far as I can see this seems to be coming from a deprecation warning being triggered by configparser.  I'm also seeing this in the Travis run for master (which is at commit a5e9784587).  I'm assuming this is related to the upgrade in pytest from 3.7.4 in your latest run on master and 3.8.0 in mine as there seems to have been some work in capturing & displaying warnings there.