### PR TITLE
Skip unchanged files which is checked

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,2 +1,3 @@
 [TYPECHECK]
 ignored-classes=pytest
+disable=bad-option-value

--- a/pytest_pylint.py
+++ b/pytest_pylint.py
@@ -166,6 +166,11 @@ def pytest_configure(config):
     config.addinivalue_line('markers', "pylint: Tests which run pylint.")
 
 
+# There will be an old-style-class error in Python 2.7,
+# or a useless-object-inheritance warning in Python 3.
+# If disable any, pylint will have a bad-option-value error in 2.7 or 3.
+# Finally I have to disable useless-object-inheritance locally
+# and bad-option-value globally.
 # pylint: disable=too-few-public-methods, useless-object-inheritance
 class PylintPlugin(object):
     """

--- a/pytest_pylint.py
+++ b/pytest_pylint.py
@@ -166,8 +166,8 @@ def pytest_configure(config):
     config.addinivalue_line('markers', "pylint: Tests which run pylint.")
 
 
-# pylint: disable=too-few-public-methods
-class PylintPlugin:
+# pylint: disable=too-few-public-methods, useless-object-inheritance
+class PylintPlugin(object):
     """
     A Plugin object for pylint, which loads and records file mtimes.
     """

--- a/test_pytest_pylint.py
+++ b/test_pytest_pylint.py
@@ -216,3 +216,27 @@ def test_pylint_ignore_patterns():
     assert include_file("part", [], ignore_patterns) is False
     assert include_file("1part2", [], ignore_patterns) is True
     assert include_file("base.py", [], ignore_patterns) is False
+
+
+def test_skip_checked_files(testdir):
+    """
+    Test a file twice which can pass pylint.
+    The 2nd time should be skipped.
+    """
+    testdir.makepyfile('''#!/usr/bin/env python
+"""A hello world script."""
+
+from __future__ import print_function
+
+print('Hello world!')
+# pylint: disable=missing-final-newline
+''')
+    # The 1st time should be passed
+    result = testdir.runpytest('--pylint')
+    print(result.stdout.str())
+    assert '1 passed' in result.stdout.str()
+
+    # The 2nd time should be skipped
+    result = testdir.runpytest('--pylint')
+    print(result.stdout.str())
+    assert '1 skipped' in result.stdout.str()

--- a/test_pytest_pylint.py
+++ b/test_pytest_pylint.py
@@ -223,20 +223,18 @@ def test_skip_checked_files(testdir):
     Test a file twice which can pass pylint.
     The 2nd time should be skipped.
     """
-    testdir.makepyfile('''#!/usr/bin/env python
-"""A hello world script."""
-
-from __future__ import print_function
-
-print('Hello world!')
-# pylint: disable=missing-final-newline
-''')
+    testdir.makepyfile(
+        '#!/usr/bin/env python',
+        '"""A hello world script."""',
+        '',
+        'from __future__ import print_function',
+        '',
+        'print("Hello world!")  # pylint: disable=missing-final-newline',
+    )
     # The 1st time should be passed
     result = testdir.runpytest('--pylint')
-    print(result.stdout.str())
     assert '1 passed' in result.stdout.str()
 
     # The 2nd time should be skipped
     result = testdir.runpytest('--pylint')
-    print(result.stdout.str())
     assert '1 skipped' in result.stdout.str()


### PR DESCRIPTION
The `pylint` is too slow, especially when the project is large.

[pytest-flakes](https://github.com/fschulze/pytest-flakes) can skip unchanged checked files by pytest cache.
This implementation is learned from that.