### PR TITLE
Fix the crash when `-p no:cacheprovider` is given.

### DIFF
--- a/test_pytest_pylint.py
+++ b/test_pytest_pylint.py
@@ -238,3 +238,7 @@ def test_skip_checked_files(testdir):
     # The 2nd time should be skipped
     result = testdir.runpytest('--pylint')
     assert '1 skipped' in result.stdout.str()
+
+    # Always be passed when cacheprovider disabled
+    result = testdir.runpytest('--pylint', '-p', 'no:cacheprovider')
+    assert '1 passed' in result.stdout.str()


### PR DESCRIPTION
The issue is #91.

I don't know someone depends on `-p no:cacheprovider`, so I didn't realize the `config.cache` could be missing. Sorry about that.

In this pull request, I add a regression test to reproduce that issue, and fix it with checking.

The pytest-pep8 has the same problem. As a result, for pytest-pylint its self, `--pep8` in `tox.ini` should be deleted, before `pytest -p no:cacheprovider` is run.