### PR TITLE
Add file and pattern ignore to cmd line

### DIFF
--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -234,3 +234,46 @@ def test_output_file(testdir):
     assert (
         'test_output_file.py:1: [W0611(unused-import), ] Unused import sys'
     ) in report
+
+
+@pytest.mark.parametrize('arg_opt_name, arg_opt_value', [
+    ('ignore', 'test_cmd_line_ignore.py'),
+    ('ignore-patterns', '.+_ignore.py'),
+], ids=['ignore', 'ignore-patterns'])
+def test_cmd_line_ignore(testdir, arg_opt_name, arg_opt_value):
+    """Verify that cmd line args ignores will work."""
+    testdir.makepyfile("""import sys""")
+    result = testdir.runpytest(
+        '--pylint', '--pylint-{0}={1}'.format(arg_opt_name, arg_opt_value)
+    )
+    assert 'collected 0 items' in result.stdout.str()
+
+
+@pytest.mark.parametrize('arg_opt_name, arg_opt_value', [
+    ('ignore', 'test_cmd_line_ignore_pri_arg.py'),
+    ('ignore-patterns', '.*arg.py$'),
+], ids=['ignore', 'ignore-patterns'])
+def test_cmd_line_ignore_pri(testdir, arg_opt_name, arg_opt_value):
+    """Verify that command line ignores and patterns take priority over
+    rcfile ignores."""
+    file_ignore = 'test_cmd_line_ignore_pri_file.py'
+    cmd_arg_ignore = 'test_cmd_line_ignore_pri_arg.py'
+    cmd_line_ignore = arg_opt_value
+
+    rcfile = testdir.makefile('rc', """
+[MASTER]
+
+{0} = {1}
+""".format(arg_opt_name, file_ignore))
+    testdir.makepyfile(**{
+        file_ignore: """import sys""",
+        cmd_arg_ignore: """import os"""
+    })
+    result = testdir.runpytest(
+        '--pylint', '--pylint-rcfile={0}'.format(rcfile.strpath),
+        '--pylint-{0}={1}'.format(arg_opt_name, cmd_line_ignore)
+    )
+
+    assert 'collected 1 item' in result.stdout.str()
+    assert 'Unused import os' not in result.stdout.str()
+    assert 'Unused import sys' in result.stdout.str()


### PR DESCRIPTION
Addresses issue #95 

Add --pylint-ignore and --pylint-ignore-patterns as command line
arguments.

These should take priority over the same option specified in the rcfile.   Although the prioritization test is currently failing.