### PR TITLE
Add ::PYLINT in pytest verbose mode

### DIFF
--- a/pytest_pylint.py
+++ b/pytest_pylint.py
@@ -269,9 +269,10 @@ class PyLintItem(pytest.Item, pytest.File):
         else:
             self._msg_format = msg_format
 
+        self._nodeid += '::PYLINT'
         self.pylintrc_file = pylintrc_file
         self.__mtime = self.fspath.mtime()
-        prev_mtime = self.config.pylint.mtimes.get(self.nodeid, 0)
+        prev_mtime = self.config.pylint.mtimes.get(self.name, 0)
         self.should_skip = (prev_mtime == self.__mtime)
 
     def setup(self):
@@ -291,7 +292,7 @@ class PyLintItem(pytest.Item, pytest.File):
             raise PyLintException('\n'.join(reported_errors))
 
         # Update the cache if the item passed pylint.
-        self.config.pylint.mtimes[self.nodeid] = self.__mtime
+        self.config.pylint.mtimes[self.name] = self.__mtime
 
     def repr_failure(self, excinfo):
         """Handle any test failures by checkint that they were ours."""

--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,4 @@ commands =
 
 [pytest]
 addopts = --pylint --pep8
+markers = pep8


### PR DESCRIPTION
Some other linter plugins will display a hint in `pytest --verbose`.

```
setup.py::YAPF PASSED
setup.py PASSED
setup.py::FLAKE8 PASSED
setup.py::ISORT PASSED
```

It is convenient with multiple linters and complex ignores.

[pytest_flake8.py#L90] is referenced.

[pytest_flake8.py#L90]:https://github.com/tholo/pytest-flake8/blob/c485d5e85ac6b2138405378e9763e7025f58b023/pytest_flake8.py#L90