### PR TITLE
Add support for pyproject.toml as pylint config file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=['pytest_pylint'],
     entry_points={'pytest11': ['pylint = pytest_pylint.plugin']},
     python_requires=">=3.5",
-    install_requires=['pytest>=5.0', 'pylint>=2.0.0'],
+    install_requires=['pytest>=5.0', 'pylint>=2.0.0', 'toml>=0.7.1'],
     setup_requires=['pytest-runner'],
     tests_require=['mock', 'coverage', 'pytest-pep8'],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pytest-pep8
     coverage
     mock
+    https://github.com/PyCQA/pylint/archive/master.tar.gz
 commands =
     coverage erase
     coverage run -m py.test {posargs}


### PR DESCRIPTION
pylint 2.5 (unreleased) can read its config also from `pyproject.toml` and `setup.cfg`. See PyCQA/pylint#3169 for details.

This PR adds support for`pyproject.toml`.