### PR TITLE
fix: #120 removing pytest deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,13 @@ target/
 
 # PyEnv
 .python-version
+
+# Virtualenv
+.venv
+.pytest-pylint
+
+# Pycharm
+.idea
+
+# Vscode
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - python: 3.6
     - python: 3.5
 install:
-  - "pip install tox-travis tox==3.14.0 coveralls"
+  - "pip install tox-travis tox==3.14.6 coveralls"
   - "pip install -e ."
 script: tox
 after_success:

--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -9,16 +9,16 @@
 
     How it works
 
-    Pytest has a number of hooks which are used as interface in order to
+    Py.test has a number of hooks which are used as interface in order to
     extends its behaviour.
-    At first, this plugin uses, in order of execution:
+    In order of execution, at first, this plugin uses the hooks:
     * pytest_addoption - Which extends parameters options to be passed to
     py.test in order to configure this plugin
     * pytest_configure - Used to add a marker, and register another Pytest
     Plugin (PylintPlugin).
 
     PylintPlugin is the plugin which contains all the logic. And also
-    implements the py.test necessary hook to interact with.
+    implements the py.test necessary hooks to interact with.
 
     Once it is registered in `pytest_configure`, the hooks already executed
     by previous plugins will run. For instance, in case PylintPlugin had
@@ -26,15 +26,15 @@
     in the hook cycle, it would be executed once PylintPlugin got registered.
 
     PylintPlugin uses the `pytest_collect_file` hook which is called wih every
-    file available in the test target dir. This hook cllects all the file
+    file available in the test target dir. This hook collects all the file
     pylint should run on, in this case files with extension ".py".
 
     `pytest_collect_file` hook returns a collection of Node, or None. In
-    Pytest context, Node being  a base class that defines py.test Collection
+    py.test context, Node being a base class that defines py.test Collection
     Tree.
 
-    A Node can be a subclass o Collector, which has children, or an Item, which
-     is a leaf node.
+    A Node can be a subclass of Collector, which has children, or an Item, which
+    is a leaf node.
 
     A pratical example would be, a test file (Collector), can have multiple
     test functions (multiple Items)
@@ -47,14 +47,14 @@
     PyLintTestFile represents a python file, extension ".py", that was
     collected based on target directory as mentioned previously.
 
-    PyLintItem represents one file which pylint was ran.
+    PyLintItem represents one file which pylint was ran or will run.
 
     Back to PylintPlugin, `pytest_collection_finish` hook will run after the
-    collection phase where pylint will be ran on the collected file.
+    collection phase where pylint will be ran on the collected files.
 
     Based on the ProgrammaticReporter, the result is stored in a dictionary
-    with the file relative path being the key, and a list of errors related to
-        the file.
+    with the file relative path of the file being the key, and a list of
+    errors related to the file.
 
     All PyLintTestFile returned during `pytest_collect_file`, returns an one
     element list of PyLintItem. The Item implements runtest method which will
@@ -262,7 +262,6 @@ class PylintPlugin:
         if should_include_file(
                 rel_path, self.pylint_ignore, self.pylint_ignore_patterns
         ):
-            # item = PyLintItem(fspath=path, parent=parent, pylint_plugin=self)
             item = PyLintTestFile.from_parent(parent, fspath=path,
                                               pylint_plugin=self)
         else:

--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -4,8 +4,8 @@ Unit testing module for pytest-pylint plugin
 """
 import os
 from textwrap import dedent
+from unittest import mock
 
-import mock
 import pytest
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     python_requires=">=3.5",
     install_requires=['pytest>=5.0', 'pylint>=2.0.0', 'toml>=0.7.1'],
     setup_requires=['pytest-runner'],
-    tests_require=['mock', 'coverage', 'pytest-pep8'],
+    tests_require=['coverage', 'pytest-flake8'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,8 @@ usedevelop = true
 deps =
     pylint
     pytest
-    pytest-pep8
+    pytest-flake8
     coverage
-    mock
 commands =
     coverage erase
     coverage run -m py.test {posargs}
@@ -17,5 +16,5 @@ commands =
     coverage html -d htmlcov
 
 [pytest]
-addopts = --pylint --pep8
-markers = pep8
+addopts = --pylint --flake8
+markers = flake8


### PR DESCRIPTION
Removing PytestDeprecationWarning.

Additional changes:
* Added an explanation of how the plugin works
* Replaced **pytest-pep8** as it hasn't been updated since 2014 and it was blocking class attributes usage.
* Removed **mock** as python 2.7 is not supported any longer

Any feedback is appreciated.
Thank you