### PR TITLE
Depend on unittest.mock instead of mock

### DIFF
--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -4,8 +4,8 @@ Unit testing module for pytest-pylint plugin
 """
 import os
 from textwrap import dedent
+from unittest import mock
 
-import mock
 import pytest
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     python_requires=">=3.5",
     install_requires=['pytest>=5.0', 'pylint>=2.0.0', 'toml>=0.7.1'],
     setup_requires=['pytest-runner'],
-    tests_require=['mock', 'coverage', 'pytest-pep8'],
+    tests_require=['coverage', 'pytest-pep8'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ deps =
     pytest
     pytest-pep8
     coverage
-    mock
 commands =
     coverage erase
     coverage run -m py.test {posargs}


### PR DESCRIPTION
Python 3.3 started to ship unittest.mock.