### PR TITLE
Fix versions of pytest and pylint in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=['pytest_pylint'],
     entry_points={'pytest11': ['pylint = pytest_pylint.plugin']},
     python_requires=">=3.5",
-    install_requires=['pytest>=5.0', 'pylint>=2.0.0', 'toml>=0.7.1'],
+    install_requires=['pytest>=5.4', 'pylint>=2.3.0', 'toml>=0.7.1'],
     setup_requires=['pytest-runner'],
     tests_require=['coverage', 'pytest-flake8'],
     classifiers=[


### PR DESCRIPTION
With pytest less than `5.4`, there will be errors below:

```shell
$ pytest
==================================== test session starts =====================================
platform linux -- Python 3.5.3, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /tmp/pytest-pylint, inifile: tox.ini
plugins: flake8-1.0.5, pylint-0.16.0
collected 0 items / 1 error                                                                  

=========================================== ERRORS ===========================================
_______________________________ ERROR collecting test session ________________________________
.env/lib/python3.5/site-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
.env/lib/python3.5/site-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
.env/lib/python3.5/site-packages/pluggy/manager.py:87: in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
pytest_pylint/plugin.py:209: in pytest_collect_file
    parent, fspath=path, plugin=self
pytest_pylint/plugin.py:274: in from_parent
    _self = getattr(super(), 'from_parent', cls)(parent, fspath=fspath)
E   TypeError: __init__() got multiple values for argument 'fspath'
!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!
====================================== 1 error in 0.12s ======================================
```

With pylint less than `2.3`, there will be another error:

```python
AttributeError: 'Import' object has no attribute 'infer_name_module'
```
