### PR TITLE
Fix tests

### DIFF
--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -83,7 +83,7 @@ def test_pylintrc_file_toml(testdir):
         '.toml',
         """
         [tool.pylint.FORMAT]
-        max-line-length = 3
+        max-line-length = "3"
         """
     )
     testdir.makepyfile('import sys')


### PR DESCRIPTION
The tests on master are broken¹ since the release of pylint 2.5 (which introduces support for pyproject.toml) as it expects `max-line-length` to be a string.

¹ See eg. https://travis-ci.com/github/michael-k/pytest-pylint/builds/163738098