### PR TITLE
pylint 2.5.1 contains breaking changes. rename do_exit => exit

### DIFF
--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -249,7 +249,7 @@ class PylintPlugin:
 
         # Run pylint over the collected files.
         try:
-            result = lint.Run(args_list, reporter=reporter, do_exit=False)
+            result = lint.Run(args_list, reporter=reporter, exit=False)
         except RuntimeError:
             return
         messages = result.linter.reporter.data

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=['pytest_pylint'],
     entry_points={'pytest11': ['pylint = pytest_pylint.plugin']},
     python_requires=">=3.5",
-    install_requires=['pytest>=5.4', 'pylint>=2.5.0', 'toml>=0.7.1'],
+    install_requires=['pytest>=5.4', 'pylint>=2.5.1', 'toml>=0.7.1'],
     setup_requires=['pytest-runner'],
     tests_require=['coverage', 'pytest-flake8'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=['pytest_pylint'],
     entry_points={'pytest11': ['pylint = pytest_pylint.plugin']},
     python_requires=">=3.5",
-    install_requires=['pytest>=5.4', 'pylint>=2.3.0', 'toml>=0.7.1'],
+    install_requires=['pytest>=5.4', 'pylint>=2.5.0', 'toml>=0.7.1'],
     setup_requires=['pytest-runner'],
     tests_require=['coverage', 'pytest-flake8'],
     classifiers=[


### PR DESCRIPTION
https://github.com/PyCQA/pylint/blob/master/ChangeLog
What's New in Pylint 2.5.1?
===========================

Release date: 2020-05-05

* Fix a crash in `method-hidden` lookup for unknown base classes

  Close #3527

* Revert pylint.Run's `exit` parameter to ``do_exit``