### PR TITLE
Fix double path before ::PYLINT

### DIFF
--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -266,7 +266,7 @@ class PylintPlugin:
         print('-' * FILL_CHARS)
 
 
-class PylintFile(pytest.File):
+class PylintFile(pytest.File):  # pylint: disable=abstract-method
     """File that pylint will run on."""
     rel_path = None  # : str
     plugin = None  # : PylintPlugin
@@ -299,7 +299,7 @@ class PylintFile(pytest.File):
         )
 
 
-class PyLintItem(pytest.Item):
+class PyLintItem(pytest.Item):  # pylint: disable=abstract-method
     """pylint test running class."""
 
     parent = None  # : PylintFile

--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -295,7 +295,7 @@ class PylintFile(pytest.File):  # pylint: disable=abstract-method
         """Create a PyLintItem for the File."""
         yield PyLintItem.from_parent(
             parent=self,
-            name='{}::PYLINT'.format(self.fspath)
+            name='PYLINT',
         )
 
 

--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -28,7 +28,7 @@ def test_nodeid(testdir):
     """Verify our nodeid adds a suffix"""
     testdir.makepyfile('import sys')
     result = testdir.runpytest('--pylint', '--collectonly')
-    assert '::PYLINT' in result.stdout.str()
+    assert 'PYLINT' in result.stdout.str()
 
 
 def test_subdirectories(testdir):

--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -142,6 +142,7 @@ def test_pylintrc_file_beside_ini(testdir):
     assert 'Line too long (10/3)' in result.stdout.str()
 
 
+# pylint: disable=not-callable
 @pytest.mark.parametrize("rcformat", ("ini", "toml", "simple_toml"))
 def test_pylintrc_ignore(testdir, rcformat):
     """Verify that a pylintrc file with ignores will work."""


### PR DESCRIPTION
## 2

There are double paths before `::PYLINT` in `pytest --verbose` mode. It is fixed in my second commit.

```shell
$ pytest -v -m pylint
=============================== test session starts ===============================
platform linux -- Python 3.7.7, pytest-6.0.0, py-1.9.0, pluggy-0.13.1 -- /home/yanqd0/pytest-pylint/.env/bin/python
cachedir: .pytest_cache
rootdir: /home/yanqd0/pytest-pylint, configfile: tox.ini
plugins: flake8-1.0.6, pylint-0.17.0
collected 38 items / 31 deselected / 7 selected                                   
--------------------------------------------------------------------------------
Linting files
.......
--------------------------------------------------------------------------------

setup.py::/home/yanqd0/pytest-pylint/setup.py::PYLINT PASSED [ 14%]
pytest_pylint/__init__.py::/home/yanqd0/pytest-pylint/pytest_pylint/__init__.py::PYLINT PASSED [ 28%]
pytest_pylint/plugin.py::/home/yanqd0/pytest-pylint/pytest_pylint/plugin.py::PYLINT PASSED [ 42%]
pytest_pylint/pylint_util.py::/home/yanqd0/pytest-pylint/pytest_pylint/pylint_util.py::PYLINT PASSED [ 57%]
pytest_pylint/util.py::/home/yanqd0/pytest-pylint/pytest_pylint/util.py::PYLINT PASSED [ 71%]
pytest_pylint/tests/test_pytest_pylint.py::/home/yanqd0/pytest-pylint/pytest_pylint/tests/test_pytest_pylint.py::PYLINT PASSED [ 85%]
pytest_pylint/tests/test_util.py::/home/yanqd0/pytest-pylint/pytest_pylint/tests/test_util.py::PYLINT PASSED [100%]

======================== 7 passed, 31 deselected in 2.63s =========================
```

## 1

There are 2 kinds of pylint issues, which fail the build.

```shell
$ pytest
=============================== test session starts ===============================
platform linux -- Python 3.7.7, pytest-6.0.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/yanqd0/pytest-pylint, configfile: tox.ini
plugins: flake8-1.0.6, pylint-0.17.0
collected 38 items
--------------------------------------------------------------------------------
Linting files
.......
--------------------------------------------------------------------------------

setup.py ..                                                                 [  5%]
pytest_pylint/__init__.py ..                                                [ 10%]
pytest_pylint/plugin.py F.                                                  [ 15%]
pytest_pylint/pylint_util.py ..                                             [ 21%]
pytest_pylint/util.py ..                                                    [ 26%]
pytest_pylint/tests/test_pytest_pylint.py F......................           [ 86%]
pytest_pylint/tests/test_util.py .....                                      [100%]

==================================== FAILURES =====================================
________________________ [pylint] pytest_pylint/plugin.py _________________________
W:269, 0: Method 'get_closest_marker' is abstract in class 'Node' but is not overridden (abstract-method)
W:269, 0: Method 'gethookproxy' is abstract in class 'FSCollector' but is not overridden (abstract-method)
W:269, 0: Method 'isinitpath' is abstract in class 'FSCollector' but is not overridden (abstract-method)
W:302, 0: Method 'get_closest_marker' is abstract in class 'Node' but is not overridden (abstract-method)
_______________ [pylint] pytest_pylint/tests/test_pytest_pylint.py ________________
E:145, 1: pytest.mark.parametrize is not callable (not-callable)
E:180, 1: pytest.mark.parametrize is not callable (not-callable)
E:284, 1: pytest.mark.parametrize is not callable (not-callable)
E:298, 1: pytest.mark.parametrize is not callable (not-callable)
============================= short test summary info =============================
FAILED pytest_pylint/plugin.py::/home/yanqd0/pytest-pylint/pytest_pylint/plugin.py::PYLINT
FAILED pytest_pylint/tests/test_pytest_pylint.py::/home/yanqd0/pytest-pylint/pytest_pylint/tests/test_pytest_pylint.py::PYLINT
========================== 2 failed, 36 passed in 4.83s ===========================
```
`abstract-method` is because `pytest 6.0.0` sets 3 methods to raise `NotImplementedError`. But they are used only in `_collectfile`, which is called in `Session`. There is no need to implement them in `File` or `Item`.

`not-callable` is more interesting. `pylint` maybe find the wrong way in `pytest 6.0.0`. It should go to [src/_pytest/python.py#L916](https://github.com/pytest-dev/pytest/blob/6.0.0/src/_pytest/python.py#L916), not to [src/_pytest/mark/structures.py#L481](https://github.com/pytest-dev/pytest/blob/6.0.0/src/_pytest/mark/structures.py#L481).

```python
# See TYPE_CHECKING above.
if TYPE_CHECKING:
    # Using casts instead of type comments intentionally - issue #7473.
    # TODO(py36): Change to builtin annotation syntax.
    skip = cast(_SkipMarkDecorator, None)
    skipif = cast(_SkipifMarkDecorator, None)
    xfail = cast(_XfailMarkDecorator, None)
    parametrize = cast(_ParametrizeMarkDecorator, None)
    usefixtures = cast(_UsefixturesMarkDecorator, None)
    filterwarnings = cast(_FilterwarningsMarkDecorator, None)
```

So, they are disabled in my first commit.