### PR TITLE
Remove runtime error lines

### DIFF
--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -271,8 +271,6 @@ class PylintPlugin:
         except TypeError:
             # pylint < 2.5.1 API
             result = lint.Run(args_list, reporter=reporter, do_exit=False)
-        except RuntimeError:
-            return
         messages = result.linter.reporter.data
         # Stores the messages in a dictionary for lookup in tests.
         for message in messages:


### PR DESCRIPTION
Due to the resulting in potential false passes.

See the following for more details:

https://github.com/pymedphys/pymedphys/issues/1305#issuecomment-761517891