### PR TITLE
feat: auto-find config that is not pylintrc based

### DIFF
--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -107,6 +107,7 @@ class PylintPlugin:
         else:
             # handling files apart from pylintrc was only introduced in pylint
             # 2.5, if we can't use find_default_config_files(), fall back on PYLINTRC
+            # once we drop support below 2.5 we can get rid of this
             try:
                 pylintrc_file = next(pylint_config.find_default_config_files(), None)
             except AttributeError:

--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -25,9 +25,9 @@ MARKER = "pylint"
 
 # handling files apart from pylintrc was only introduced in pylint 2.5, if we
 # can't use find_default_config_files(), fall back on PYLINTRC
-if hasattr(pylint.config, "find_default_config_files"):
+try:
     PYLINTRC = next(pylint.config.find_default_config_files(), None)
-else:
+except AttributeError:
     PYLINTRC = pylint.config.PYLINTRC
 
 

--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -10,10 +10,10 @@ from configparser import ConfigParser, NoOptionError, NoSectionError
 from os import makedirs
 from os.path import dirname, exists, getmtime, join
 
+import pylint.config
 import pytest
 import toml
 from pylint import lint
-import pylint.config
 
 from .pylint_util import ProgrammaticReporter
 from .util import PyLintException, get_rel_path, should_include_file

--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -13,7 +13,7 @@ from os.path import dirname, exists, getmtime, join
 import pytest
 import toml
 from pylint import lint
-from pylint.config import PYLINTRC
+from pylint.config import find_default_config_files
 
 from .pylint_util import ProgrammaticReporter
 from .util import PyLintException, get_rel_path, should_include_file
@@ -102,7 +102,9 @@ class PylintPlugin:
         """Configure pytest after it is already enabled"""
 
         # Find pylintrc to check ignore list
-        pylintrc_file = config.option.pylint_rcfile or PYLINTRC
+        pylintrc_file = config.option.pylint_rcfile or next(
+            find_default_config_files(), None
+        )
 
         if pylintrc_file and not exists(pylintrc_file):
             # The directory of pytest.ini got a chance

--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -129,7 +129,10 @@ def test_pylintrc_file_pyproject_toml(testdir):
     testdir.makepyfile("import sys")
     result = testdir.runpytest("--pylint")
 
-    assert list(pylint.config.find_default_config_files()) == []
+    assert (
+        os.path.basename(next(pylint.config.find_default_config_files(), None))
+        == "pyproject.toml"
+    )
     assert "Line too long (10/3)" in result.stdout.str()
 
 

--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -113,6 +113,32 @@ def test_pylintrc_file_toml(testdir):
     assert "Line too long (10/3)" in result.stdout.str()
 
 
+def test_pylintrc_file_pyproject_toml(testdir):
+    """Verify that pyproject.toml can be used as a pylint rc file."""
+    testdir.makefile(
+        ".toml",
+        pyproject="""
+        [tool.pylint.FORMAT]
+        max-line-length = "3"
+        """,
+    )
+    testdir.makepyfile("import sys")
+    result = testdir.runpytest("--pylint")
+    # Parsing changed from integer to string in pylint >=2.5. Once
+    # support is dropped <2.5 this is removable
+    if "should be of type int" in result.stdout.str():
+        testdir.makefile(
+            ".toml",
+            pylint="""
+            [tool.pylint.FORMAT]
+            max-line-length = 3
+            """,
+        )
+        result = testdir.runpytest("--pylint")
+
+    assert "Line too long (10/3)" in result.stdout.str()
+
+
 def test_pylintrc_file_beside_ini(testdir):
     """
     Verify that a specified pylint rc file will work what placed into pytest

--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -7,7 +7,7 @@ import re
 from textwrap import dedent
 from unittest import mock
 
-import pylint
+import pylint.config
 import pytest
 
 pytest_plugins = ("pytester",)  # pylint: disable=invalid-name
@@ -117,8 +117,7 @@ def test_pylintrc_file_toml(testdir):
 def test_pylintrc_file_pyproject_toml(testdir):
     """Verify that pyproject.toml can be auto-detected as a pylint rc file."""
     # pylint only auto-detects pyproject.toml from 2.5 onwards
-    version_string = pylint.version
-    if version_string.startswith("2.3") or version_string.startswith("2.4"):
+    if not hasattr(pylint.config, "find_default_config_files"):
         return
     testdir.makefile(
         ".toml",

--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -129,10 +129,6 @@ def test_pylintrc_file_pyproject_toml(testdir):
     testdir.makepyfile("import sys")
     result = testdir.runpytest("--pylint")
 
-    assert (
-        os.path.basename(next(pylint.config.find_default_config_files(), None))
-        == "pyproject.toml"
-    )
     assert "Line too long (10/3)" in result.stdout.str()
 
 

--- a/pytest_pylint/tests/test_pytest_pylint.py
+++ b/pytest_pylint/tests/test_pytest_pylint.py
@@ -129,6 +129,7 @@ def test_pylintrc_file_pyproject_toml(testdir):
     testdir.makepyfile("import sys")
     result = testdir.runpytest("--pylint")
 
+    assert list(pylint.config.find_default_config_files()) == []
     assert "Line too long (10/3)" in result.stdout.str()
 
 


### PR DESCRIPTION
Changes the way that the config file is retrieved from pylint.config. Previously
this was done using the static `variable pylint.config.PYLINTRC` which is defined
at load by iterating over all the files found via
`pylint.config.find_default_config_files()` until one ending in "pylintrc" is
found. In pylint itself config seems instead to be found by calling
`next(find_default_config_files(), None)` which is also able to find setup.cfg or
pyproject.toml based config files automatically. I have thus changed PyLintPlugin
to use the same version and can now call `py.test --pylint` and have config from
my pyproject.toml picked up correctly.

I have added one additional test, essentially copying the existing
`test_pylint_file_toml`, but now called `test_pyline_file_pyproject_toml`, which
is modified to name the config file `pyproject.toml` and does not pass the
`--pyline-fcfile` option but expects it to be auto-detected. This test passes
when the file is called pyproject.toml but fails when it is called something
different.