### PR TITLE
pin major version of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=["pytest_pylint"],
     entry_points={"pytest11": ["pylint = pytest_pylint.plugin"]},
     python_requires=">=3.7",
-    install_requires=["pytest>=5.4", "pylint>=2.3.0", "toml>=0.7.1"],
+    install_requires=["pytest~=5.4", "pylint~=2.3", "toml~=0.7"],
     setup_requires=["pytest-runner"],
     tests_require=["coverage", "flake8", "black", "isort"],
     classifiers=[


### PR DESCRIPTION
Release of new major versions of dependencies currently has the potential of breaking compatibility. (As just happened with pylint 3.0.0) To prevent this we pin the versions to be compatible.