### PR TITLE
Updates for new Python, Drop Py 3.7, and Support Pylint 3.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"
-        - "3.11.0-rc - 3.11"
+        - "3.11"
+        - "3.12.0-rc - 3.12"
 
     steps:
       - uses: actions/checkout@v3

--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -391,4 +391,5 @@ class PyLintItem(pytest.Item):
 
     def reportinfo(self):
         """Generate our test report"""
+        # pylint: disable=no-member
         return self.fspath, None, f"[pylint] {self.parent.rel_path}"

--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -111,6 +111,7 @@ class PylintPlugin:
             try:
                 pylintrc_file = next(pylint_config.find_default_config_files(), None)
             except AttributeError:
+                # pylint: disable=no-member
                 pylintrc_file = pylint_config.PYLINTRC
 
         if pylintrc_file and not exists(pylintrc_file):

--- a/pytest_pylint/pylint_util.py
+++ b/pytest_pylint/pylint_util.py
@@ -2,14 +2,12 @@
 """Pylint reporter classes."""
 import sys
 
-from pylint.interfaces import IReporter
 from pylint.reporters import BaseReporter
 
 
 class ProgrammaticReporter(BaseReporter):
     """Reporter that replaces output with storage in list of dictionaries"""
 
-    __implements__ = IReporter
     extension = "prog"
 
     def __init__(self, output=None):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=["pytest_pylint"],
     entry_points={"pytest11": ["pylint = pytest_pylint.plugin"]},
     python_requires=">=3.7",
-    install_requires=["pytest>=5.4", "pylint>=2.3.0", "toml>=0.7.1"],
+    install_requires=["pytest>=5.4,<8.0", "pylint>=2.3.0", "toml>=0.7.1"],
     setup_requires=["pytest-runner"],
     tests_require=["coverage", "flake8", "black", "isort"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ pytest-pylint
 
 Plugin for py.test for doing pylint tests
 """
-
+# pylint: disable=import-error
 from setuptools import setup
 
 with open("README.rst", encoding="utf-8") as f:

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     pytestmain: git+https://github.com/pytest-dev/pytest.git@main#egg=pytest
     coverage
 commands =
-    coverage run -m py.test {posargs}
+    coverage run -m pytest {posargs}
 
 [testenv:coverage]
 depends = py3{7, 8, 9, 10, 11}-pylint{215, latest, main}-pytest{71, latest, main}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     py3{8, 9}-pylint{26, 30}-pytest{54}
     py3{8, 9, 10}-pylint{213, 214, 30}-pytest{71}
-    py3{8, 9, 10, 11, 12}-pylint{215, latest, main}-pytest{71, latest}
+    py3{8, 9, 10, 11}-pylint{215, latest, main}-pytest{71, latest}
+    py3{12}-pylint{latest, main}-pytest{71, latest}
     coverage
     qa
 skip_missing_interpreters = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py3{8, 9}-pylint{23, 30}-pytest{54}
+    py3{8, 9}-pylint{26, 30}-pytest{54}
     py3{8, 9, 10}-pylint{213, 214, 30}-pytest{71}
-    py3{8, 9, 10, 11, 12}-pylint{215, latest, main}-pytest{71, latest, main}
+    py3{8, 9, 10, 11, 12}-pylint{215, latest, main}-pytest{71, latest}
     coverage
     qa
 skip_missing_interpreters = true
@@ -11,15 +11,14 @@ skip_missing_interpreters = true
 usedevelop = true
 deps =
     pylint30: pylint~=3.0
-    pylint23: pylint~=2.3.1
+    pylint26: pylint~=2.6.0
     pylint213: pylint~=2.13.9
     pylint214: pylint~=2.14.5
     pylint215: pylint~=2.15.0
     pylintlatest: pylint
     pylintmain: git+https://github.com/PyCQA/pylint.git@main#egg=pylint
     pylintmain: git+https://github.com/PyCQA/astroid.git@main#egg=astroid
-    pytest54: pytest~=5.4.3
-    pytest71: pytest~=7.1.2
+    pytest7: pytest~=7.1.2
     pytestlatest: pytest
     pytestmain: git+https://github.com/pytest-dev/pytest.git@main#egg=pytest
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py3{7, 8, 9}-pylint{23}-pytest{54}
-    py3{7, 8, 9, 10}-pylint{213, 214}-pytest{71}
-    py3{7, 8, 9, 10, 11}-pylint{215, latest, main}-pytest{71, latest, main}
+    py3{8, 9}-pylint{23, 30}-pytest{54}
+    py3{8, 9, 10}-pylint{213, 214, 30}-pytest{71}
+    py3{8, 9, 10, 11, 12}-pylint{215, latest, main}-pytest{71, latest, main}
     coverage
     qa
 skip_missing_interpreters = true
@@ -10,6 +10,7 @@ skip_missing_interpreters = true
 [testenv]
 usedevelop = true
 deps =
+    pylint30: pylint~=3.0
     pylint23: pylint~=2.3.1
     pylint213: pylint~=2.13.9
     pylint214: pylint~=2.14.5


### PR DESCRIPTION
This is primarily to fix things in order to work with pylint 3. I plan to release from here, and then rapidly make another release that drops support for Pre 2.6 pylint and pre 7.0 pytest as well. I just wanted to get something out there that will fix folks for pylint 3.0 without breaking folks with older pytest