### PR TITLE
Use `pathlib.Path` in plugin hooks

### DIFF
--- a/pytest_pylint/plugin.py
+++ b/pytest_pylint/plugin.py
@@ -220,16 +220,16 @@ class PylintPlugin:
         if hasattr(session.config, "cache"):
             session.config.cache.set(HISTKEY, self.mtimes)
 
-    def pytest_collect_file(self, path, parent):
+    def pytest_collect_file(self, file_path, parent):
         """Collect files on which pylint should run"""
-        if path.ext != ".py":
+        if file_path.suffix != ".py":
             return None
 
-        rel_path = get_rel_path(path.strpath, str(parent.session.path))
+        rel_path = file_path.relative_to(parent.session.path)
         if should_include_file(
-            rel_path, self.pylint_ignore, self.pylint_ignore_patterns
+            str(rel_path), self.pylint_ignore, self.pylint_ignore_patterns
         ):
-            item = PylintFile.from_parent(parent, path=Path(path), plugin=self)
+            item = PylintFile.from_parent(parent, path=file_path, plugin=self)
         else:
             return None
 


### PR DESCRIPTION
Fixes compatibility with pytest 8.1, see
- pytest-dev/pytest#8144
- https://docs.pytest.org/en/stable/changelog.html#id282
- https://docs.pytest.org/en/stable/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path

Fixes carsongee/pytest-pylint#192