### PR TITLE
Use latest actions in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,13 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
-        - "3.12.0-rc - 3.12"
+        - "3.12"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Fixes:

    Node.js 16 actions are deprecated. Please update the following
    actions to use Node.js 20: actions/checkout@v3,
    actions/setup-python@v3. For more information see:
    https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The test failures are unrelated.  I'm happy to rebase once they are fixed. :)